### PR TITLE
fix dive duration bug

### DIFF
--- a/src/DivingCalculator.Web/e2e/deco-dive-to-100m-for-30-mins.spec.ts
+++ b/src/DivingCalculator.Web/e2e/deco-dive-to-100m-for-30-mins.spec.ts
@@ -84,7 +84,7 @@ test('deco dive to 100m for 30 mins', async ({ page }) => {
 
   await addDiveSegmentPage.setTimeAtDepth(30);
   expect(await addDiveSegmentPage.getFinalCeiling()).toBe('49m');
-  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('37 min 48 sec');
+  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('36 min');
 
   diveOverviewPage = await addDiveSegmentPage.Save();
 
@@ -130,7 +130,7 @@ test('deco dive to 100m for 30 mins', async ({ page }) => {
 
   await addDiveSegmentPage.setTimeAtDepth(20);
   expect(await addDiveSegmentPage.getFinalCeiling()).toBe('23m');
-  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('71 min 42 sec');
+  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('61 min 42 sec');
 
   let decoMilestones = await addDiveSegmentPage.getDecoMilestones();
   expect(decoMilestones[0]).toBe('3 min 45 sec : Helitrox 35/25 @ 35m');
@@ -184,7 +184,7 @@ test('deco dive to 100m for 30 mins', async ({ page }) => {
 
   await addDiveSegmentPage.setTimeAtDepth(41);
   expect(await addDiveSegmentPage.getFinalCeiling()).toBe('7m');
-  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('109 min 6 sec');
+  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('104 min 48 sec');
 
   decoMilestones = await addDiveSegmentPage.getDecoMilestones();
   expect(decoMilestones[0]).toBe('41 min 39 sec : Oxygen @ 6m');
@@ -235,7 +235,7 @@ test('deco dive to 100m for 30 mins', async ({ page }) => {
 
   await addDiveSegmentPage.setTimeAtDepth(33);
   expect(await addDiveSegmentPage.getFinalCeiling()).toBe('1m');
-  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('141 min 36 sec');
+  expect(await addDiveSegmentPage.getTotalDiveDuration()).toBe('139 min 24 sec');
 
   decoMilestones = await addDiveSegmentPage.getDecoMilestones();
   expect(decoMilestones[0]).toBe('33 min 3 sec : Deco complete @ 0m');
@@ -250,7 +250,7 @@ test('deco dive to 100m for 30 mins', async ({ page }) => {
   expect(diveSegments[10].heading).toBe('done 2:19:24 Surface');
   expect(diveSegments[10].details).toBe('Ascent time: 36 sec @ 10m/min');
 
-  expect(await diveOverviewPage.getDiveDuration()).toBe('140 min');
+  expect(await diveOverviewPage.getDiveDuration()).toBe('140 min'); // TODO: shouldn't this be at least 141 mins as per line 238
   expect(await diveOverviewPage.getMaxDepth()).toBe('100m');
   expect(await diveOverviewPage.getAverageDepth()).toBe('41m');
 

--- a/src/DivingCalculator.Web/src/app/dive-planner-service/DivePlannerService.ts
+++ b/src/DivingCalculator.Web/src/app/dive-planner-service/DivePlannerService.ts
@@ -68,6 +68,10 @@ export class DivePlannerService {
     return this.diveProfile.getCurrentGas();
   }
 
+  getCurrentDiveTime(): number {
+    return this.diveProfile.getCurrentDiveTime();
+  }
+
   getNoDecoLimit(newDepth: number, newGas: BreathingGas): number | undefined {
     return this.diveProfile.getNoDecoLimit(newDepth, newGas);
   }

--- a/src/DivingCalculator.Web/src/app/dive-planner-service/DiveProfile.ts
+++ b/src/DivingCalculator.Web/src/app/dive-planner-service/DiveProfile.ts
@@ -66,6 +66,10 @@ export class DiveProfile {
     return this.getPreviousSegment().Gas;
   }
 
+  getCurrentDiveTime(): number {
+    return this.getPreviousSegment().EndTimestamp;
+  }
+
   getNoDecoLimit(newDepth: number, newGas: BreathingGas): number | undefined {
     const wipProfile = this.getCurrentProfile();
 

--- a/src/DivingCalculator.Web/src/app/new-time-stats/new-time-stats.component.ts
+++ b/src/DivingCalculator.Web/src/app/new-time-stats/new-time-stats.component.ts
@@ -40,7 +40,7 @@ export class NewTimeStatsComponent implements OnChanges {
   }
 
   private getTotalDiveDuration(): number {
-    return this.divePlanner.getDiveDuration() + this.divePlanner.getTravelTime(this.newDepth) + this.timeAtDepth * 60;
+    return this.divePlanner.getCurrentDiveTime() + this.divePlanner.getTravelTime(this.newDepth) + this.timeAtDepth * 60;
   }
 
   private getDecoMilestones(data: { time: number; ceiling: number }[]): { duration: number; gas: string; depth: number; tooltip: string }[] {


### PR DESCRIPTION
Fixes #199 

The code was incorrectly including the ascent segment (which was no longer correct given the changes in progress) in the total dive time. This corrects it to use CurrentTotalDiveTime which excludes the last (generated) ascent segment.