### PR TITLE
fix tissues to start at atmosphere partials instead of 0

### DIFF
--- a/src/src/app/dive-planner-service/Tissue.ts
+++ b/src/src/app/dive-planner-service/Tissue.ts
@@ -115,7 +115,7 @@ export class Tissue {
   }
 
   private getTissueByTime(time: number): { PN2: number; PHe: number } {
-    return this.tissueByTime.get(time) ?? { PN2: 0, PHe: 0 };
+    return this.tissueByTime.get(time) ?? { PN2: this.ENVIRONMENT_PN2, PHe: this.ENVIRONMENT_PHE };
   }
 
   private getPN2Delta(tissuePN2: number, gasPN2: number): number {


### PR DESCRIPTION
This pull request includes a small but significant change to the `Tissue` class in the `dive-planner-service`. The change ensures that the default values for `PN2` and `PHe` are set to the environmental constants instead of zero.